### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/__test__/test.js
+++ b/__test__/test.js
@@ -15,3 +15,10 @@ it('expand should expand objects with keys in dot notation', () => {
     }
   })
 })
+
+it('expand should not expand objects with blacklisted keys', () => {
+  let out = expand({ '__proto__.polluted': true })
+
+  expect(out).toMatchObject({})
+  expect({}.polluted).toBe(undefined)
+})

--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ Object.defineProperty(exports, '__esModule', {
 
 exports.default = exports.expand = (obj, opts = {}) => {
   return Object.keys(obj).reduce((a, c) => {
+    if (isBlackListed(c)) return a
     set(a, c, obj[c])
     return a
   }, {})
 }
+
+const isBlackListed = (string) => /__proto__|constructor|prototype/.test(string)


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/dot-expand/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/dot-expand/1/README.md

### User Comments:

### :bar_chart: Metadata *

`dot-expand` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-dot-expand

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { expand } = require('dot-expand')

console.log('Before: ', {}.polluted)
expand({'__proto__.polluted': true})
console.log('After: ', {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i dot-expand # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105280296-7426f480-5bcf-11eb-8129-1fac0ab84a6f.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
